### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/assets/vendore/texllate/jquery.lettering.js
+++ b/frontend/assets/vendore/texllate/jquery.lettering.js
@@ -11,11 +11,21 @@
 * Date: Mon Sep 20 17:14:00 2010 -0600
 */
 (function($){
+	// Simple HTML escaping function
+	function escapeHtml(text) {
+		return String(text)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	}
+
 	function injector(t, splitter, klass, after) {
 		var a = t.text().split(splitter), inject = '';
 		if (a.length) {
 			$(a).each(function(i, item) {
-				inject += '<span class="'+klass+(i+1)+'">'+item+'</span>'+after;
+				inject += '<span class="'+klass+(i+1)+'">'+escapeHtml(item)+'</span>'+after;
 			});	
 			t.empty().append(inject);
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/jarvis/security/code-scanning/6](https://github.com/vannu07/jarvis/security/code-scanning/6)

To fix the issue, all text coming from the DOM (via `t.text()`) should be escaped before being added as HTML content using string concatenation and `.append()`. The best way is to properly encode the `item` variable before concatenation in line 18, so HTML metacharacters are converted to entities (e.g., `<` becomes `&lt;`). In jQuery, a common approach is to use `document.createTextNode` to escape text, but since we are building HTML as a string, we need an explicit escaping function.

- Add an escape function to convert metacharacters to their HTML entity forms.
- Use this function to escape `item` before concatenating.
- All edits must be inside the relevant code you have been shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
