### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black-format.yml
+++ b/.github/workflows/black-format.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Check formatting with Black


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/jarvis/security/code-scanning/1](https://github.com/vannu07/jarvis/security/code-scanning/1)

To fix this, add a `permissions:` block to the `lint` job, setting it to the minimal required scope, which is `contents: read` (since this job only checks formatting and does not need to write to the repository, nor access issues or pull requests). This should be inserted under `runs-on:` (before `steps:`) in the `lint` job section. No other code or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
