### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "*" ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/jarvis/security/code-scanning/2](https://github.com/vannu07/jarvis/security/code-scanning/2)

The best fix is to explicitly set a minimal `permissions` block for the workflow, either at the root level (top of the file, applying to all jobs) or at the job level (inside `jobs.lint`). As the lint job only needs to checkout contents and does not make repository changes, `contents: read` is sufficient. Add a block:
```yaml
permissions:
  contents: read
```
either above `jobs:` or under `jobs.lint`. Since no other jobs are present, and the job does not interact with pull requests/issues or modify repo data, this change will not affect functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
