### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/assets/vendore/texllate/jquery.lettering.js
+++ b/frontend/assets/vendore/texllate/jquery.lettering.js
@@ -24,7 +24,7 @@
 	function injector(t, splitter, klass, after) {
 		var a = t.text().split(splitter), inject = '';
 		if (a.length) {
-			$(a).each(function(i, item) {
+			$.each(a, function(i, item) {
 				inject += '<span class="'+klass+(i+1)+'">'+escapeHtml(item)+'</span>'+after;
 			});	
 			t.empty().append(inject);


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/jarvis/security/code-scanning/7](https://github.com/vannu07/jarvis/security/code-scanning/7)

To fix this problem, the unsafe use of `$(a).each(...)` should be replaced with `$.each(a, ...)`. The `$.each` function iterates safely over arrays and objects, passing each element to the callback function without attempting to interpret the values as selectors, DOM, or HTML.  
Update the code in frontend/assets/vendore/texllate/jquery.lettering.js, specifically lines 27-29, so that iteration over the array `a` uses `$.each(a, ...)` instead of `$(a).each(...)`.  
No new methods or imports are required. The rest of the code, including escaping, can remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
