### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/backend/feature.py
+++ b/backend/feature.py
@@ -312,7 +312,7 @@ def findContact(query):
         if not mobile_number.startswith(WHATSAPP_COUNTRY_CODE):
             mobile_number = WHATSAPP_COUNTRY_CODE + mobile_number
 
-        StatusIndicator.success(f"Contact found: {query}")
+        StatusIndicator.success("Contact found")
         return mobile_number, query
     except Exception as e:
         StatusIndicator.error(f"Error in findContact: {e}")
@@ -324,15 +324,15 @@ def findContact(query):
 def whatsApp(Phone, message, flag, name):
     if flag == "message":
         target_tab = 12
-        jarvis_message = "Message sent successfully to " + name
+        jarvis_message = "Message sent successfully."
     elif flag == "call":
         target_tab = 7
         message = ""
-        jarvis_message = "Calling " + name
+        jarvis_message = "Calling contact..."
     else:
         target_tab = 6
         message = ""
-        jarvis_message = "Starting video call with " + name
+        jarvis_message = "Starting video call..."
 
     StatusIndicator.processing("Initiating WhatsApp action")
     


### PR DESCRIPTION
Potential fix for [https://github.com/vannu07/jarvis/security/code-scanning/10](https://github.com/vannu07/jarvis/security/code-scanning/10)

General approach: avoid logging sensitive user data (phone numbers, contact names, free-form messages) and, where logging is desirable for UX, restrict it to non-identifying or sanitized summaries. Since `StatusIndicator` is used widely, the least invasive change is to adjust the specific messages that include contact-identifying information (`jarvis_message` and similar) so that they no longer contain names or other PII, while preserving user-facing voice feedback via `speak` as needed.

Best concrete fix without changing overall functionality:

- In `backend/feature.py`:
  - In `findContact`, keep using the contact’s phone number and name internally, but change the success feedback to something generic that doesn’t include the normalized query (which may be the person’s name). For example, replace `StatusIndicator.success(f"Contact found: {query}")` with `StatusIndicator.success("Contact found")`. This still informs the user that a contact was found without logging PII.
  - In `whatsApp`, stop including `name` in the status message passed to `StatusIndicator.success`. Instead of:
    - `"Message sent successfully to " + name`
    - `"Calling " + name`
    - `"Starting video call with " + name`
    use generic variants like:
    - `"Message sent successfully."`
    - `"Calling contact..."`
    - `"Starting video call..."`.
  - Optionally, you can still use the more detailed `jarvis_message` (with the name) for `speak` if you consider spoken output not to be “logging”. However, since `speak` also pushes text to `eel.DisplayMessage`/`eel.receiverText`, it’s safer to align that as well with the generic message. I will keep `speak(jarvis_message)` as-is only in structure—`jarvis_message` itself will become generic and no longer contain the name.

These changes only touch the content of strings passed to `StatusIndicator` and `speak`; they do not affect external behavior other than making visible messages more privacy-preserving. No new functions or imports are required.

Specific locations:

- `backend/feature.py`:
  - Around line 315: update `StatusIndicator.success(f"Contact found: {query}")`.
  - Around lines 324–335: update the three `jarvis_message` assignments to remove inclusion of `name`.

No changes are needed in `backend/feedback.py` itself, since its sanitizer and printing mechanism are already generic; the problem is the content being sent into it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
